### PR TITLE
Test shedule plan

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,9 @@ linters:
     - lll
     - mnd
     - gomnd
+    - testpackage
+    - wsl
+    - paralleltest
 
 linters-settings:
   goimports:
@@ -52,3 +55,6 @@ issues:
     - path: cmd/.*
       linters:
         - forbidigo
+    - path: _test.go
+      linters:
+        - funlen

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,22 +15,8 @@ func main() {
 	rotationFlag := flag.Int("rotation", 24*7, "Rotation time in hours. Default is one week")
 	startFlag := flag.String("start", "", "Shift start date")
 	endFlag := flag.String("end", "", "Shift end date")
-	configFileFlag := flag.String("config", "config.json", "Config file path")
+	configFileFlag := flag.String("config", "", "Config file path")
 	flag.Parse()
-
-	start, err := time.Parse("2006-01-02", *startFlag)
-	if err != nil {
-		flag.PrintDefaults()
-		fmt.Println("Invalid start time")
-		os.Exit(1)
-	}
-
-	end, err := time.Parse("2006-01-02", *endFlag)
-	if err != nil {
-		flag.PrintDefaults()
-		fmt.Println("Invalid end time")
-		os.Exit(1)
-	}
 
 	config, err := os.ReadFile(*configFileFlag)
 	if err != nil {
@@ -43,6 +29,20 @@ func main() {
 	if err := json.Unmarshal(config, &c); err != nil {
 		flag.PrintDefaults()
 		fmt.Println("Config file could not be parsed")
+		os.Exit(1)
+	}
+
+	start, err := time.Parse("2006-01-02", *startFlag)
+	if err != nil {
+		flag.PrintDefaults()
+		fmt.Println("Invalid start time")
+		os.Exit(1)
+	}
+
+	end, err := time.Parse("2006-01-02", *endFlag)
+	if err != nil {
+		flag.PrintDefaults()
+		fmt.Println("Invalid end time")
 		os.Exit(1)
 	}
 

--- a/internal/shift/plan.go
+++ b/internal/shift/plan.go
@@ -41,7 +41,7 @@ func (sr *ShiftRotation) Plan(start time.Time, end time.Time, rotation time.Dura
 		secondary := sr.findSecondary(shiftplan, s, e)
 		sr.team = remove(sr.team, secondary)
 
-		shift := apis.Shift{Start: s, End: e, Primary: primary, Secondary: secondary}
+		shift := apis.Shift{Start: s, End: e, Primary: primary.ID, Secondary: secondary.ID}
 		shiftplan = append(shiftplan, shift)
 
 		sr.team = append(sr.team, secondary, primary)

--- a/internal/shift/plan_test.go
+++ b/internal/shift/plan_test.go
@@ -1,0 +1,193 @@
+package shift
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/orltom/on-call-schedule/pkg/apis"
+)
+
+func TestNewDefaultShiftRotationShiftRotation_Plan(t *testing.T) {
+	type args struct {
+		start    time.Time
+		end      time.Time
+		rotation time.Duration
+	}
+	tests := []struct {
+		name      string
+		employees []apis.Employee
+		args      args
+		want      []apis.Shift
+	}{
+		{
+			name: "Daily Schedule without vacation days",
+			employees: []apis.Employee{
+				{
+					ID:           "a@test.ch",
+					Name:         "a",
+					VacationDays: nil,
+				},
+				{
+					ID:           "b@test.ch",
+					Name:         "b",
+					VacationDays: nil,
+				},
+			},
+			args: args{
+				start:    date("2020-04-01"),
+				end:      date("2020-04-04"),
+				rotation: 24 * time.Hour,
+			},
+			want: []apis.Shift{
+				{
+					Start:     date("2020-04-01"),
+					End:       date("2020-04-02"),
+					Primary:   "a@test.ch",
+					Secondary: "b@test.ch",
+				},
+				{
+					Start:     date("2020-04-02"),
+					End:       date("2020-04-03"),
+					Primary:   "b@test.ch",
+					Secondary: "a@test.ch",
+				},
+				{
+					Start:     date("2020-04-03"),
+					End:       date("2020-04-04"),
+					Primary:   "a@test.ch",
+					Secondary: "b@test.ch",
+				},
+			},
+		},
+		{
+			name: "Should not schedule Primary on holiday days",
+			employees: []apis.Employee{
+				{
+					ID:           "a@test.ch",
+					Name:         "a",
+					VacationDays: []time.Time{date("2020-04-01")},
+				},
+				{
+					ID:           "b@test.ch",
+					Name:         "b",
+					VacationDays: nil,
+				},
+				{
+					ID:           "c@test.ch",
+					Name:         "c",
+					VacationDays: nil,
+				},
+				{
+					ID:           "d@test.ch",
+					Name:         "d",
+					VacationDays: nil,
+				},
+			},
+			args: args{
+				start:    date("2020-04-01"),
+				end:      date("2020-04-05"),
+				rotation: 24 * time.Hour,
+			},
+			want: []apis.Shift{
+				{
+					Start:     date("2020-04-01"),
+					End:       date("2020-04-02"),
+					Primary:   "b@test.ch",
+					Secondary: "c@test.ch",
+				},
+				{
+					Start:     date("2020-04-02"),
+					End:       date("2020-04-03"),
+					Primary:   "a@test.ch",
+					Secondary: "d@test.ch",
+				},
+				{
+					Start:     date("2020-04-03"),
+					End:       date("2020-04-04"),
+					Primary:   "c@test.ch",
+					Secondary: "b@test.ch",
+				},
+				{
+					Start:     date("2020-04-04"),
+					End:       date("2020-04-05"),
+					Primary:   "d@test.ch",
+					Secondary: "a@test.ch",
+				},
+			},
+		},
+		{
+			name: "Should not schedule Secondary on holiday days",
+			employees: []apis.Employee{
+				{
+					ID:           "a@test.ch",
+					Name:         "a",
+					VacationDays: nil,
+				},
+				{
+					ID:           "b@test.ch",
+					Name:         "b",
+					VacationDays: []time.Time{date("2020-04-01")},
+				},
+				{
+					ID:           "c@test.ch",
+					Name:         "c",
+					VacationDays: nil,
+				},
+				{
+					ID:           "d@test.ch",
+					Name:         "d",
+					VacationDays: nil,
+				},
+			},
+			args: args{
+				start:    date("2020-04-01"),
+				end:      date("2020-04-05"),
+				rotation: 24 * time.Hour,
+			},
+			want: []apis.Shift{
+				{
+					Start:     date("2020-04-01"),
+					End:       date("2020-04-02"),
+					Primary:   "a@test.ch",
+					Secondary: "c@test.ch",
+				},
+				{
+					Start:     date("2020-04-02"),
+					End:       date("2020-04-03"),
+					Primary:   "b@test.ch",
+					Secondary: "d@test.ch",
+				},
+				{
+					Start:     date("2020-04-03"),
+					End:       date("2020-04-04"),
+					Primary:   "c@test.ch",
+					Secondary: "a@test.ch",
+				},
+				{
+					Start:     date("2020-04-04"),
+					End:       date("2020-04-05"),
+					Primary:   "d@test.ch",
+					Secondary: "b@test.ch",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shiftRotation := NewDefaultShiftRotation(tt.employees)
+			if got := shiftRotation.Plan(tt.args.start, tt.args.end, tt.args.rotation); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Plan() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func date(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+
+	return t
+}

--- a/internal/shift/rules.go
+++ b/internal/shift/rules.go
@@ -27,7 +27,7 @@ func InvolvedInLastSift(e apis.Employee, shifts []apis.Shift, _ time.Time, _ tim
 	}
 
 	lastShift := shifts[len(shifts)-1]
-	if lastShift.Primary.Name == e.Name || lastShift.Secondary.Name == e.Name {
+	if lastShift.Primary == e.ID || lastShift.Secondary == e.ID {
 		return true
 	}
 

--- a/pkg/apis/config.go
+++ b/pkg/apis/config.go
@@ -6,7 +6,10 @@ type Config struct {
 	Employees []Employee `json:"employees"`
 }
 
+type EmployeeID string
+
 type Employee struct {
+	ID           EmployeeID  `json:"id"`
 	Name         string      `json:"name"`
 	VacationDays []time.Time `json:"vacationDays,omitempty"`
 }

--- a/pkg/apis/shift.go
+++ b/pkg/apis/shift.go
@@ -8,12 +8,12 @@ import (
 type Shift struct {
 	Start     time.Time
 	End       time.Time
-	Primary   Employee
-	Secondary Employee
+	Primary   EmployeeID
+	Secondary EmployeeID
 }
 
 func (s Shift) String() string {
-	return fmt.Sprintf("%s - %s = %s (%s)\n", s.Start.Format("2006-01-02"), s.End.Format("2006-01-02"), s.Primary.Name, s.Secondary.Name)
+	return fmt.Sprintf("%s - %s = %s (%s)\n", s.Start.Format("2006-01-02"), s.End.Format("2006-01-02"), s.Primary, s.Secondary)
 }
 
 type ShiftConflictChecker func(primary Employee, shifts []Shift, start time.Time, end time.Time) bool


### PR DESCRIPTION
# Context
Write some basic tests to verify the behaviour of the on-call schedule generator

# API Changes
An employee ID has been introduced to identify on-call duty and reduce the data complexity of the generated schedule. The shift plan refers to this ID instead of the employee structure.