### PR TITLE
Failure detection when no on-call duty is available for the shift

### DIFF
--- a/cmd/create_command.go
+++ b/cmd/create_command.go
@@ -102,7 +102,11 @@ func RunCreateShiftPlan(arguments []string) error {
 		return fmt.Errorf("%w: invalid team config file: %w", ErrInvalidArgument, err)
 	}
 
-	plan := shiftplan.NewDefaultShiftPlanner(team.Employees).Plan(*str, *end, time.Duration(*duration)*time.Hour)
+	plan, err := shiftplan.NewDefaultShiftPlanner(team.Employees).Plan(*str, *end, time.Duration(*duration)*time.Hour)
+	if err != nil {
+		return fmt.Errorf("can not create on-call schedule: %w", err)
+	}
+
 	if err := converters[transform]().Write(plan, os.Stdout); err != nil {
 		return fmt.Errorf("unexpecting error: %w", err)
 	}

--- a/internal/shiftplan/default_rules.go
+++ b/internal/shiftplan/default_rules.go
@@ -14,8 +14,8 @@ type DefaultRule struct {
 	fn func(e apis.Employee, _ []apis.Shift, start time.Time, end time.Time) bool
 }
 
-func (d *DefaultRule) Match(primary apis.Employee, shifts []apis.Shift, start time.Time, end time.Time) bool {
-	return d.fn(primary, shifts, start, end)
+func (d *DefaultRule) Match(employee apis.Employee, shifts []apis.Shift, start time.Time, end time.Time) bool {
+	return d.fn(employee, shifts, start, end)
 }
 
 func VacationConflict() *DefaultRule {

--- a/internal/shiftplan/default_rules_test.go
+++ b/internal/shiftplan/default_rules_test.go
@@ -1,0 +1,119 @@
+package shiftplan
+
+import (
+	"testing"
+	"time"
+
+	"github.com/orltom/on-call-schedule/pkg/apis"
+)
+
+func TestVacationConflict(t *testing.T) {
+	type args struct {
+		employee apis.Employee
+		start    time.Time
+		end      time.Time
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Should detect conflict if employee has holiday between scheduled shift",
+			args: args{
+				employee: apis.Employee{ID: "a", Name: "a", VacationDays: []string{"2024-01-01"}},
+				start:    date("2024-01-01"),
+				end:      date("2024-01-02"),
+			},
+			want: true,
+		},
+		{
+			name: "Should not detect conflict if employee has no holidays",
+			args: args{
+				employee: apis.Employee{ID: "a", Name: "a", VacationDays: nil},
+				start:    date("2024-01-01"),
+				end:      date("2024-01-02"),
+			},
+			want: false,
+		},
+		{
+			name: "Should not detect conflict if employee has holiday outside scheduled shift",
+			args: args{
+				employee: apis.Employee{ID: "a", Name: "a", VacationDays: []string{"2024-01-03"}},
+				start:    date("2024-01-01"),
+				end:      date("2024-01-02"),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := VacationConflict()
+			if got := d.Match(tt.args.employee, nil, tt.args.start, tt.args.end); got != tt.want {
+				t.Errorf("Match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInvolvedInLastSift(t *testing.T) {
+	type args struct {
+		employee apis.Employee
+		shifts   []apis.Shift
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Should not detect conflict when start with the first schedule shift",
+			args: args{
+				employee: apis.Employee{ID: "a", Name: "a", VacationDays: nil},
+				shifts:   nil,
+			},
+			want: false,
+		},
+		{
+			name: "Should not detect conflict if employee was not on last shift",
+			args: args{
+				employee: apis.Employee{ID: "a", Name: "a", VacationDays: nil},
+				shifts: []apis.Shift{{
+					Primary:   "b",
+					Secondary: "c",
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "Should detect conflict if employee was on last shift as primary",
+			args: args{
+				employee: apis.Employee{ID: "a", Name: "a", VacationDays: nil},
+				shifts: []apis.Shift{{
+					Primary:   "a",
+					Secondary: "b",
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "Should detect conflict if employee was on last shift as secondary",
+			args: args{
+				employee: apis.Employee{ID: "a", Name: "a", VacationDays: nil},
+				shifts: []apis.Shift{{
+					Primary:   "c",
+					Secondary: "a",
+				}},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := InvolvedInLastSift()
+			if got := d.Match(tt.args.employee, tt.args.shifts, time.Now(), time.Now()); got != tt.want {
+				t.Errorf("Match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/plan_types.go
+++ b/pkg/apis/plan_types.go
@@ -13,7 +13,7 @@ type Shift struct {
 }
 
 type Rule interface {
-	Match(primary Employee, shifts []Shift, start time.Time, end time.Time) bool
+	Match(employee Employee, shifts []Shift, start time.Time, end time.Time) bool
 }
 
 type Exporter interface {


### PR DESCRIPTION
fix #10 

# Changes
- Return error when none on-call duty is available
- Only add rules to the Default Planner that are independent of the organisation and the law. To do this, remove the InvolvedInLastSift rule from the Default Planner rule set.