### PR TITLE
Enable schedule rules via CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ go.work.sum
 
 # build
 /ocs
+/ocsctl
 /demo.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,6 +137,6 @@ issues:
       linters:
         - funlen
         - dupl
-    - path: pkg/apis/team_types.go
+    - path: pkg/apis/team_methods.go
       linters:
         - wrapcheck

--- a/README.md
+++ b/README.md
@@ -2,30 +2,66 @@
 [![License](https://img.shields.io/github/license/orltom/on-call-schedule)](/LICENSE)
 
 # On-Call Schedule
-It helps to create or synchronize on-call schedules for team members, allowing users to define custom rules or use 
-predefined ones. Important factors, such as absences due to holidays or other time off, are automatically considered.
+This tool is a flexible command-line tool designed to simplify the creation and management of on-call schedules 
+for on-call teams. It addresses common limitations in existing incident management tools, such as lack of calendar 
+syncing, inadequate handling of holidays, and inflexible scheduling rules.
+
+# ✨ Current Features
+- Custom Rule-Based On-Call Scheduling: Create on-call schedules based on your own rules or use default rules, such as holiday checkers.
+- Multiple Export Formats: Generate on-call schedules in various formats, including CSV and JSON
+
+# 🛠️ Planned Features
+- iCalender Export
+- Automatically generate on-call schedules by syncing with a shared group calendar.
+- Export schedules directly to popular incident management tools.
+
+
+# Installation
+To install the latest version of ocsctl:
+```shell
+go install github.com/orltom/on-call-schedule@latest
+```
+
+Or clone the repository and build manually:
+
+```shell
+git clone https://github.com/orltom/on-call-schedule.git
+go build -o ocsctl ./cmd
+```
 
 ## Usage
+### Create on-call schedule plan
 Here is an example of how to create an on-call duty plan
 ```shell
-> cat > demo.json << EOL
+cat > team.json << EOL
 {
   "employees": [
     {"id": "joe@example.com", "name": "Joe"},
     {"id": "jan@example.com", "name": "Jan", "vacationDays": ["2024-01-06","2024-01-07"]},
-    {"id": "lee@example.com", "name": "Lee"}
+    {"id": "lee@example.com", "name": "Lee"},
+    {"id": "eva@example.com", "name": "Eva"}
   ]
 }
 EOL
 
-./ocsctl create \
+ocsctl create \
         --start "2024-01-01 00:00:00" \
         --end "2024-03-29 00:00:00" \
         --duration 168 \
-        --team-file demo.json \
+        --team-file team.json \
+        --primary-rules=vacation,minimumfourshiftgap
+        --secondary-rules=vacation,minimumtwoshiftgap
         --output table
 ```
+## Help Command
+```shell
+ocsctl [command] -h
+```
+
 
 ## Contributing
 Contributions are welcome in any form, be it code, logic, documentation, examples, requests, bug reports, ideas or
 anything else that will help this project move forward.
+
+## License
+This project is licensed under the MIT License. See the LICENSE file for more details.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ EOL
 ./ocsctl create \
         --start "2024-01-01 00:00:00" \
         --end "2024-03-29 00:00:00" \
+        --duration 168 \
         --team-file demo.json \
         --output table
 ```

--- a/cmd/create_command.go
+++ b/cmd/create_command.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/orltom/on-call-schedule/internal/cli"
@@ -14,22 +14,17 @@ import (
 	"github.com/orltom/on-call-schedule/pkg/apis"
 )
 
-var (
-	ErrMissingArguments = errors.New("missing required flag")
-	ErrInvalidArgument  = errors.New("invalid value")
-)
-
-type Converter int
+type Format int
 
 const (
-	CVS Converter = iota
+	CVS Format = iota
 	Table
 	JSON
 )
 
 func RunCreateShiftPlan(arguments []string) error {
-	enums := map[string]Converter{"CVS": CVS, "Table": Table, "json": JSON}
-	converters := map[Converter]func() apis.Exporter{
+	enums := map[string]Format{"CVS": CVS, "Table": Table, "json": JSON}
+	exporters := map[Format]func() apis.Exporter{
 		Table: func() apis.Exporter {
 			return export.NewTableExporter()
 		},
@@ -41,20 +36,24 @@ func RunCreateShiftPlan(arguments []string) error {
 		},
 	}
 
-	str := new(time.Time)
+	start := new(time.Time)
 	end := new(time.Time)
+	primaryRules := new(string)
+	secondaryRules := new(string)
 	duration := new(int)
 	teamFilePath := new(string)
-	transform := Table
+	outputFormat := Table
 	var showHelp bool
 
 	createCommand := flag.NewFlagSet("create", flag.ExitOnError)
 	createCommand.BoolVar(&showHelp, "h", false, "help for ocsctl create")
-	createCommand.IntVar(duration, "duration", 7*24, "shift duration in hours.")
-	createCommand.Func("start", "(required) start time of the schedule plan", cli.TimeValueVar(str))
+	createCommand.IntVar(duration, "duration", 7*24, "shift duration in hours")
+	createCommand.Func("start", "(required) start time of the schedule plan", cli.TimeValueVar(start))
 	createCommand.Func("end", "(required) end time of the schedule plan", cli.TimeValueVar(end))
 	createCommand.Func("team-file", "(required) path to the file that contain all on-call duties", cli.FilePathVar(teamFilePath))
-	createCommand.Func("output", "output format. One of (cvs, table, json)", cli.EnumValueVar(enums, &transform))
+	createCommand.Func("output", "output format. One of (cvs, table, json)", cli.EnumValueVar(enums, &outputFormat))
+	createCommand.StringVar(primaryRules, "primary-rules", "vacation", "Rule to decide which employee should be on-call for the next shift")
+	createCommand.StringVar(secondaryRules, "secondary-rules", "vacation", "Rule to decide which employee should be on-call for the next shift")
 	createCommand.Usage = func() {
 		fmt.Fprintf(os.Stdout, "Create on-call schedule\n")
 		fmt.Fprintf(os.Stdout, "\nUsage\n")
@@ -74,47 +73,42 @@ func RunCreateShiftPlan(arguments []string) error {
 		return nil
 	}
 
-	// check that the required flags are set...
-	if !cli.IsFlagPassed(createCommand, "start") {
+	// validate CLI arguments...
+	if ok, missed := cli.RequiredFlagPassed(createCommand, "start", "end", "team-file"); !ok {
 		createCommand.Usage()
-		return fmt.Errorf("%w: %s", ErrMissingArguments, "start")
+		return fmt.Errorf("missing required flag: %s", strings.Join(missed, ","))
 	}
 
-	if !cli.IsFlagPassed(createCommand, "end") {
-		createCommand.Usage()
-		return fmt.Errorf("%w: %s", ErrMissingArguments, "end")
-	}
-
-	if !cli.IsFlagPassed(createCommand, "team-file") {
-		createCommand.Usage()
-		return fmt.Errorf("%w: %s", ErrMissingArguments, "team-file")
-	}
-
-	// validate input data...
-	if str == end {
-		createCommand.Usage()
-		return ErrInvalidArgument
-	}
-
-	// initialize and run...
-	team, err := parse(*teamFilePath)
+	// initialize...
+	team, err := readTeamFile(*teamFilePath)
 	if err != nil {
-		return fmt.Errorf("%w: invalid team config file: %w", ErrInvalidArgument, err)
+		return fmt.Errorf("could not read %s: %w", *teamFilePath, err)
 	}
 
-	plan, err := shiftplan.NewDefaultShiftPlanner(team.Employees).Plan(*str, *end, time.Duration(*duration)*time.Hour)
+	pRules, err := mapPrimaryRules(*primaryRules)
+	if err != nil {
+		return fmt.Errorf("invalid rules: %w", err)
+	}
+
+	sRules, err := mapSecondaryRules(*secondaryRules)
+	if err != nil {
+		return fmt.Errorf("invalid rules: %w", err)
+	}
+
+	// run...
+	plan, err := shiftplan.NewShiftPlanner(team.Employees, pRules, sRules).Plan(*start, *end, time.Duration(*duration)*time.Hour)
 	if err != nil {
 		return fmt.Errorf("can not create on-call schedule: %w", err)
 	}
 
-	if err := converters[transform]().Write(plan, os.Stdout); err != nil {
+	if err := exporters[outputFormat]().Write(plan, os.Stdout); err != nil {
 		return fmt.Errorf("unexpecting error: %w", err)
 	}
 
 	return nil
 }
 
-func parse(path string) (apis.Team, error) {
+func readTeamFile(path string) (apis.Team, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return apis.Team{}, fmt.Errorf("could not read file '%s': %w", path, err)
@@ -122,8 +116,50 @@ func parse(path string) (apis.Team, error) {
 
 	var team apis.Team
 	if err := json.Unmarshal(content, &team); err != nil {
-		return apis.Team{}, fmt.Errorf("could not pars json file '%s': %w", path, err)
+		return apis.Team{}, fmt.Errorf("could not parse json file '%s': %w", path, err)
 	}
 
 	return team, nil
+}
+
+func mapPrimaryRules(value string) ([]apis.Rule, error) {
+	var rules []apis.Rule
+	for _, s := range strings.Split(value, ",") {
+		switch strings.ToLower(s) {
+		case "vacation":
+			rules = append(rules, shiftplan.NewNoVacationOverlap())
+		case "minimumoneshiftgap":
+			rules = append(rules, shiftplan.NewMinimumPrimaryGapBetweenShifts(1))
+		case "minimumtwoshiftgap":
+			rules = append(rules, shiftplan.NewMinimumPrimaryGapBetweenShifts(2))
+		case "minimumthreeshiftgap":
+			rules = append(rules, shiftplan.NewMinimumPrimaryGapBetweenShifts(3))
+		case "minimumfourshiftgap":
+			rules = append(rules, shiftplan.NewMinimumPrimaryGapBetweenShifts(4))
+		default:
+			return nil, fmt.Errorf("unknow rule: %s", s)
+		}
+	}
+	return rules, nil
+}
+
+func mapSecondaryRules(value string) ([]apis.Rule, error) {
+	var rules []apis.Rule
+	for _, s := range strings.Split(value, ",") {
+		switch strings.ToLower(s) {
+		case "vacation":
+			rules = append(rules, shiftplan.NewNoVacationOverlap())
+		case "minimumoneshiftgap":
+			rules = append(rules, shiftplan.NewMinimumSecondaryGapBetweenShifts(1))
+		case "minimumtwoshiftgap":
+			rules = append(rules, shiftplan.NewMinimumSecondaryGapBetweenShifts(2))
+		case "minimumthreeshiftgap":
+			rules = append(rules, shiftplan.NewMinimumSecondaryGapBetweenShifts(3))
+		case "minimumfourshiftgap":
+			rules = append(rules, shiftplan.NewMinimumSecondaryGapBetweenShifts(4))
+		default:
+			return nil, fmt.Errorf("unknow rule: %s", s)
+		}
+	}
+	return rules, nil
 }

--- a/cmd/create_command.go
+++ b/cmd/create_command.go
@@ -50,7 +50,7 @@ func RunCreateShiftPlan(arguments []string) error {
 
 	createCommand := flag.NewFlagSet("create", flag.ExitOnError)
 	createCommand.BoolVar(&showHelp, "h", false, "help for ocsctl create")
-	createCommand.IntVar(duration, "rotation", 7*24, "rotation time in hours.")
+	createCommand.IntVar(duration, "duration", 7*24, "shift duration in hours.")
 	createCommand.Func("start", "(required) start time of the schedule plan", cli.TimeValueVar(str))
 	createCommand.Func("end", "(required) end time of the schedule plan", cli.TimeValueVar(end))
 	createCommand.Func("team-file", "(required) path to the file that contain all on-call duties", cli.FilePathVar(teamFilePath))

--- a/cmd/create_command.go
+++ b/cmd/create_command.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -22,7 +23,7 @@ const (
 	JSON
 )
 
-func RunCreateShiftPlan(arguments []string) error {
+func RunCreateShiftPlan(writer io.Writer, arguments []string) error {
 	enums := map[string]Format{"CVS": CVS, "Table": Table, "json": JSON}
 	exporters := map[Format]func() apis.Exporter{
 		Table: func() apis.Exporter {
@@ -55,12 +56,12 @@ func RunCreateShiftPlan(arguments []string) error {
 	createCommand.StringVar(primaryRules, "primary-rules", "vacation", "Rule to decide which employee should be on-call for the next shift")
 	createCommand.StringVar(secondaryRules, "secondary-rules", "vacation", "Rule to decide which employee should be on-call for the next shift")
 	createCommand.Usage = func() {
-		fmt.Fprintf(os.Stdout, "Create on-call schedule\n")
-		fmt.Fprintf(os.Stdout, "\nUsage\n")
-		fmt.Fprintf(os.Stdout, "  %s create [flags]\n", os.Args[0])
-		fmt.Fprintf(os.Stdout, "\nFlags:\n")
+		fmt.Fprintf(writer, "Create on-call schedule\n")
+		fmt.Fprintf(writer, "\nUsage\n")
+		fmt.Fprintf(writer, "  %s create [flags]\n", os.Args[0])
+		fmt.Fprintf(writer, "\nFlags:\n")
 		flag.PrintDefaults()
-		fmt.Fprintf(os.Stdout, "\nUse \"%s create -h\" for more information about a command\n", os.Args[0])
+		fmt.Fprintf(writer, "\nUse \"%s create -h\" for more information about a command\n", os.Args[0])
 	}
 
 	if err := createCommand.Parse(arguments); err != nil {
@@ -101,7 +102,7 @@ func RunCreateShiftPlan(arguments []string) error {
 		return fmt.Errorf("can not create on-call schedule: %w", err)
 	}
 
-	if err := exporters[outputFormat]().Write(plan, os.Stdout); err != nil {
+	if err := exporters[outputFormat]().Write(plan, writer); err != nil {
 		return fmt.Errorf("unexpecting error: %w", err)
 	}
 

--- a/cmd/create_command_test.go
+++ b/cmd/create_command_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCreateShiftPlan(t *testing.T) {
+	dir := t.TempDir()
+	tempFilePath := filepath.Join(dir, "team.json")
+	content := `{"employees": [{"id": "joe@example.com", "name": "Joe"}, {"id": "jan@example.com", "name": "Jan"}]}`
+	if err := os.WriteFile(tempFilePath, []byte(content), 0o600); err != nil {
+		t.FailNow()
+	}
+
+	type args struct {
+		arguments []string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantWriter string
+		wantErrMsg string
+	}{
+		{
+			name:       "Print Usage when required flags are missing",
+			wantWriter: "Usage",
+			wantErrMsg: "missing required flag: start,end,team-file",
+		},
+		{
+			name: "Print Usage when use help flag",
+			args: args{
+				arguments: []string{
+					"-h",
+				},
+			},
+			wantWriter: "Usage",
+			wantErrMsg: "",
+		},
+		{
+			name: "Print an on-call schedule in JSON format",
+			args: args{
+				arguments: []string{
+					"--start", "2024-01-01 00:00:00",
+					"--end", "2024-01-08 00:00:00",
+					"--team-file", tempFilePath,
+					"--output", "json",
+				},
+			},
+			wantWriter: `[{"start":"2024-01-01T00:00:00Z","end":"2024-01-08T00:00:00Z","primary":"joe@example.com","secondary":"jan@example.com"}]`,
+			wantErrMsg: "",
+		},
+		{
+			name: "Print an error if shift plan cannot be created if rules are too restricted",
+			args: args{
+				arguments: []string{
+					"--start", "2024-01-01 00:00:00",
+					"--end", "2024-01-15 00:00:00",
+					"--team-file", tempFilePath,
+					"--primary-rules", "minimumfourshiftgap",
+					"--output", "json",
+				},
+			},
+			wantWriter: "",
+			wantErrMsg: "can not create on-call schedule: could not find available duty between 2024-01-08 00:00:00 +0000 UTC and 2024-01-15 00:00:00 +0000 UTC",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := &bytes.Buffer{}
+			err := RunCreateShiftPlan(writer, tt.args.arguments)
+			if (err != nil) && tt.wantErrMsg != err.Error() {
+				t.Errorf("RunCreateShiftPlan() error = %v, wantErr %v", err, tt.wantErrMsg)
+				return
+			}
+			if gotWriter := writer.String(); !strings.Contains(gotWriter, tt.wantWriter) {
+				t.Errorf("RunCreateShiftPlan() gotWriter = %v, want %v", gotWriter, tt.wantWriter)
+			}
+		})
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 )
@@ -13,7 +14,7 @@ var ErrCommandNotFound = errors.New("command not found")
 type command struct {
 	name        string
 	description string
-	run         func([]string) error
+	run         func(io.Writer, []string) error
 }
 
 func main() {
@@ -67,7 +68,7 @@ func runCommand(cmd string, commands []command) error {
 		return fmt.Errorf("%w: %s", ErrCommandNotFound, cmd)
 	}
 
-	if err := commands[cmdIdx].run(os.Args[2:]); err != nil {
+	if err := commands[cmdIdx].run(os.Stdout, os.Args[2:]); err != nil {
 		return fmt.Errorf("\n\n%w", err)
 	}
 

--- a/internal/cli/flagset_helper.go
+++ b/internal/cli/flagset_helper.go
@@ -10,14 +10,21 @@ import (
 	"time"
 )
 
-func IsFlagPassed(f *flag.FlagSet, name string) bool {
-	found := false
-	f.Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			found = true
-		}
+func RequiredFlagPassed(f *flag.FlagSet, names ...string) (bool, []string) {
+	var missedFlags []string
+	visited := make(map[string]bool)
+
+	f.Visit(func(fl *flag.Flag) {
+		visited[fl.Name] = true
 	})
-	return found
+
+	for _, name := range names {
+		if !visited[name] {
+			missedFlags = append(missedFlags, name)
+		}
+	}
+
+	return len(missedFlags) == 0, missedFlags
 }
 
 func TimeValueVar(t *time.Time) func(s string) error {

--- a/internal/export/cv.go
+++ b/internal/export/cv.go
@@ -1,6 +1,7 @@
 package export
 
 import (
+	"encoding/csv"
 	"fmt"
 	"io"
 	"time"
@@ -12,19 +13,25 @@ var _ apis.Exporter = &CVSExporter{}
 
 type CVSExporter struct{}
 
+func NewCVSCExporter() *CVSExporter {
+	return &CVSExporter{}
+}
+
 func (c *CVSExporter) Write(shifts []apis.Shift, writer io.Writer) error {
-	if _, err := fmt.Fprint(writer, "from,to,primary,secondary\n"); err != nil {
+	csvWriter := csv.NewWriter(writer)
+	defer csvWriter.Flush()
+
+	if err := csvWriter.Write([]string{"Start", "End", "Primary", "Secondary"}); err != nil {
 		return fmt.Errorf("write csv header: %w", err)
 	}
+
 	for i := range shifts {
 		s := shifts[i]
-		if _, err := fmt.Fprintf(writer, "\"%s\",\"%s\",\"%s\",\"%s\"\n", s.Start.Format(time.DateOnly), s.End.Format(time.DateOnly), s.Primary, s.Secondary); err != nil {
+		record := []string{s.Start.Format(time.DateOnly), s.End.Format(time.DateOnly), string(s.Primary), string(s.Secondary)}
+		if err := csvWriter.Write(record); err != nil {
 			return fmt.Errorf("write csv data: %w", err)
 		}
 	}
-	return nil
-}
 
-func NewCVSCExporter() *CVSExporter {
-	return &CVSExporter{}
+	return nil
 }

--- a/internal/export/cv_test.go
+++ b/internal/export/cv_test.go
@@ -36,9 +36,9 @@ func TestCVSExporter_Write(t *testing.T) {
 					},
 				},
 			},
-			wantWriter: `from,to,primary,secondary
-"2024-12-25","2024-12-26","a","b"
-"2024-12-26","2024-12-27","c","d"
+			wantWriter: `Start,End,Primary,Secondary
+2024-12-25,2024-12-26,a,b
+2024-12-26,2024-12-27,c,d
 `,
 			wantErr: false,
 		},
@@ -47,7 +47,7 @@ func TestCVSExporter_Write(t *testing.T) {
 			args: args{
 				plan: []apis.Shift{},
 			},
-			wantWriter: "from,to,primary,secondary\n",
+			wantWriter: "Start,End,Primary,Secondary\n",
 			wantErr:    false,
 		},
 		{
@@ -55,7 +55,7 @@ func TestCVSExporter_Write(t *testing.T) {
 			args: args{
 				plan: nil,
 			},
-			wantWriter: "from,to,primary,secondary\n",
+			wantWriter: "Start,End,Primary,Secondary\n",
 			wantErr:    false,
 		},
 	}

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -13,6 +13,10 @@ var _ apis.Exporter = &JSONExporter{}
 
 type JSONExporter struct{}
 
+func NewJSONExporter() *JSONExporter {
+	return &JSONExporter{}
+}
+
 func (c *JSONExporter) Write(plan []apis.Shift, writer io.Writer) error {
 	if plan == nil {
 		return errors.New("plan must not be nil")
@@ -29,8 +33,4 @@ func (c *JSONExporter) Write(plan []apis.Shift, writer io.Writer) error {
 	}
 
 	return nil
-}
-
-func NewJSONExporter() *JSONExporter {
-	return &JSONExporter{}
 }

--- a/internal/export/table.go
+++ b/internal/export/table.go
@@ -44,14 +44,9 @@ func (e *TableExporter) Write(plan []apis.Shift, writer io.Writer) error {
 func truncate(item reflect.Value) (string, error) {
 	var maxLen = 15
 	v := fmt.Sprintf("%v", item.Interface())
-	if len(v) == maxLen {
-		return v, nil
-	}
-
 	if len(v) > maxLen {
 		return v[:12] + "...", nil
 	}
-
 	return v + strings.Repeat(" ", maxLen-len(v)-1), nil
 }
 
@@ -59,11 +54,9 @@ func formatDateOnly(item reflect.Value) (string, error) {
 	if item.Kind() != reflect.Struct {
 		return "", ErrNotDate
 	}
-
 	t, ok := item.Interface().(time.Time)
 	if !ok {
 		return "", ErrNotDate
 	}
-
 	return t.Format(time.DateOnly), nil
 }

--- a/internal/shiftplan/default_rules.go
+++ b/internal/shiftplan/default_rules.go
@@ -21,7 +21,7 @@ func (d *DefaultRule) Match(employee apis.Employee, shifts []apis.Shift, start t
 func VacationConflict() *DefaultRule {
 	return &DefaultRule{
 		fn: func(e apis.Employee, _ []apis.Shift, start time.Time, end time.Time) bool {
-			days := e.Vacations()
+			days := e.VacationDays
 			for vIdx := range days {
 				day := days[vIdx]
 				if (day.After(start) && day.Before(end)) || day.Equal(start) || day.Equal(end) {

--- a/internal/shiftplan/default_rules.go
+++ b/internal/shiftplan/default_rules.go
@@ -6,44 +6,53 @@ import (
 	"github.com/orltom/on-call-schedule/pkg/apis"
 )
 
-var _ apis.Rule = VacationConflict()
-
-var _ apis.Rule = InvolvedInLastSift()
-
-type DefaultRule struct {
-	fn func(e apis.Employee, _ []apis.Shift, start time.Time, end time.Time) bool
-}
-
-func (d *DefaultRule) Match(employee apis.Employee, shifts []apis.Shift, start time.Time, end time.Time) bool {
-	return d.fn(employee, shifts, start, end)
-}
-
-func VacationConflict() *DefaultRule {
-	return &DefaultRule{
-		fn: func(e apis.Employee, _ []apis.Shift, start time.Time, end time.Time) bool {
-			days := e.VacationDays
-			for vIdx := range days {
-				day := days[vIdx]
-				if (day.After(start) && day.Before(end)) || day.Equal(start) || day.Equal(end) {
-					return true
-				}
+func NewNoVacationOverlap() apis.RuleFunc {
+	return func(e apis.Employee, _ []apis.Shift, start time.Time, end time.Time) bool {
+		days := e.VacationDays
+		for vIdx := range days {
+			day := days[vIdx]
+			if (day.After(start) && day.Before(end)) || day.Equal(start) || day.Equal(end) {
+				return true
 			}
-			return false
-		},
+		}
+		return false
 	}
 }
 
-func InvolvedInLastSift() *DefaultRule {
-	return &DefaultRule{
-		fn: func(e apis.Employee, shifts []apis.Shift, _ time.Time, _ time.Time) bool {
-			if len(shifts) == 0 {
-				return false
-			}
-			lastShift := shifts[len(shifts)-1]
-			if lastShift.Primary == e.ID || lastShift.Secondary == e.ID {
+func NewMinimumPrimaryGapBetweenShifts(gap int) apis.RuleFunc {
+	return func(e apis.Employee, shifts []apis.Shift, _ time.Time, _ time.Time) bool {
+		if len(shifts) == 0 {
+			return false
+		}
+
+		lowIndex := 0
+		if len(shifts) > gap {
+			lowIndex = len(shifts) - gap
+		}
+		for idx := range shifts[lowIndex:] {
+			if shifts[idx].Primary == e.ID {
 				return true
 			}
+		}
+		return false
+	}
+}
+
+func NewMinimumSecondaryGapBetweenShifts(gap int) apis.RuleFunc {
+	return func(e apis.Employee, shifts []apis.Shift, _ time.Time, _ time.Time) bool {
+		if len(shifts) == 0 {
 			return false
-		},
+		}
+
+		lowIndex := 0
+		if len(shifts) > gap {
+			lowIndex = len(shifts) - gap
+		}
+		for idx := range shifts[lowIndex:] {
+			if shifts[idx].Secondary == e.ID {
+				return true
+			}
+		}
+		return false
 	}
 }

--- a/internal/shiftplan/default_rules_test.go
+++ b/internal/shiftplan/default_rules_test.go
@@ -21,7 +21,7 @@ func TestVacationConflict(t *testing.T) {
 		{
 			name: "Should detect conflict if employee has holiday between scheduled shift",
 			args: args{
-				employee: apis.Employee{ID: "a", Name: "a", VacationDays: []string{"2024-01-01"}},
+				employee: apis.Employee{ID: "a", Name: "a", VacationDays: vacationDays("2024-01-01")},
 				start:    date("2024-01-01"),
 				end:      date("2024-01-02"),
 			},
@@ -39,7 +39,7 @@ func TestVacationConflict(t *testing.T) {
 		{
 			name: "Should not detect conflict if employee has holiday outside scheduled shift",
 			args: args{
-				employee: apis.Employee{ID: "a", Name: "a", VacationDays: []string{"2024-01-03"}},
+				employee: apis.Employee{ID: "a", Name: "a", VacationDays: vacationDays("2024-01-03")},
 				start:    date("2024-01-01"),
 				end:      date("2024-01-02"),
 			},

--- a/internal/shiftplan/planner.go
+++ b/internal/shiftplan/planner.go
@@ -30,11 +30,11 @@ func NewShiftPlanner(team []apis.Employee, primaryConflictCheckers []apis.Rule, 
 	}
 }
 
-func (p *ShiftPlanner) Plan(start time.Time, end time.Time, rotation time.Duration) ([]apis.Shift, error) {
+func (p *ShiftPlanner) Plan(start time.Time, end time.Time, duration time.Duration) ([]apis.Shift, error) {
 	var plan []apis.Shift
 
-	for s := start; s.Before(end); s = s.Add(rotation) {
-		e := s.Add(rotation)
+	for s := start; s.Before(end); s = s.Add(duration) {
+		e := s.Add(duration)
 
 		primary, err := p.findPrimary(plan, s, e)
 		if err != nil {

--- a/internal/shiftplan/planner.go
+++ b/internal/shiftplan/planner.go
@@ -17,16 +17,25 @@ type ShiftPlanner struct {
 func NewDefaultShiftPlanner(team []apis.Employee) *ShiftPlanner {
 	return NewShiftPlanner(
 		team,
-		[]apis.Rule{VacationConflict()},
-		[]apis.Rule{VacationConflict()},
+		[]apis.Rule{NewNoVacationOverlap()},
+		[]apis.Rule{NewNoVacationOverlap()},
 	)
 }
 
 func NewShiftPlanner(team []apis.Employee, primaryConflictCheckers []apis.Rule, secondaryConflictCheckers []apis.Rule) *ShiftPlanner {
+	t := make([]apis.Employee, len(team))
+	copy(t, team)
+
+	p := make([]apis.Rule, len(primaryConflictCheckers))
+	copy(p, primaryConflictCheckers)
+
+	s := make([]apis.Rule, len(secondaryConflictCheckers))
+	copy(s, secondaryConflictCheckers)
+
 	return &ShiftPlanner{
-		team:                     team,
-		primaryConflictCheckers:  primaryConflictCheckers,
-		secondaryConflictChecker: secondaryConflictCheckers,
+		team:                     t,
+		primaryConflictCheckers:  p,
+		secondaryConflictChecker: s,
 	}
 }
 

--- a/internal/shiftplan/planner_test.go
+++ b/internal/shiftplan/planner_test.go
@@ -12,7 +12,7 @@ func TestPlanner_Plan(t *testing.T) {
 	type args struct {
 		start    time.Time
 		end      time.Time
-		rotation time.Duration
+		duration time.Duration
 	}
 	tests := []struct {
 		name      string
@@ -30,7 +30,7 @@ func TestPlanner_Plan(t *testing.T) {
 			args: args{
 				start:    date("2020-04-01"),
 				end:      date("2020-04-04"),
-				rotation: 24 * time.Hour,
+				duration: 24 * time.Hour,
 			},
 			want: []apis.Shift{
 				{
@@ -65,7 +65,7 @@ func TestPlanner_Plan(t *testing.T) {
 			args: args{
 				start:    date("2020-04-01"),
 				end:      date("2020-04-05"),
-				rotation: 24 * time.Hour,
+				duration: 24 * time.Hour,
 			},
 			want: []apis.Shift{
 				{
@@ -106,7 +106,7 @@ func TestPlanner_Plan(t *testing.T) {
 			args: args{
 				start:    date("2020-04-01"),
 				end:      date("2020-04-05"),
-				rotation: 24 * time.Hour,
+				duration: 24 * time.Hour,
 			},
 			want: []apis.Shift{
 				{
@@ -147,7 +147,7 @@ func TestPlanner_Plan(t *testing.T) {
 			args: args{
 				start:    date("2020-04-01"),
 				end:      date("2020-04-04"),
-				rotation: 24 * time.Hour,
+				duration: 24 * time.Hour,
 			},
 			want:    nil,
 			wantErr: true,
@@ -163,7 +163,7 @@ func TestPlanner_Plan(t *testing.T) {
 			args: args{
 				start:    date("2020-04-01"),
 				end:      date("2020-04-04"),
-				rotation: 24 * time.Hour,
+				duration: 24 * time.Hour,
 			},
 			want:    nil,
 			wantErr: true,
@@ -172,7 +172,7 @@ func TestPlanner_Plan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			planner := NewDefaultShiftPlanner(tt.employees)
-			got, err := planner.Plan(tt.args.start, tt.args.end, tt.args.rotation)
+			got, err := planner.Plan(tt.args.start, tt.args.end, tt.args.duration)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Plan() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/shiftplan/planner_test.go
+++ b/internal/shiftplan/planner_test.go
@@ -57,7 +57,7 @@ func TestPlanner_Plan(t *testing.T) {
 		{
 			name: "Should not schedule Primary on holiday days",
 			employees: []apis.Employee{
-				{ID: "a@test.ch", Name: "a", VacationDays: []string{"2020-04-01"}},
+				{ID: "a@test.ch", Name: "a", VacationDays: vacationDays("2020-04-01")},
 				{ID: "b@test.ch", Name: "b", VacationDays: nil},
 				{ID: "c@test.ch", Name: "c", VacationDays: nil},
 				{ID: "d@test.ch", Name: "d", VacationDays: nil},
@@ -99,7 +99,7 @@ func TestPlanner_Plan(t *testing.T) {
 			name: "Should not schedule Secondary on holiday days",
 			employees: []apis.Employee{
 				{ID: "a@test.ch", Name: "a", VacationDays: nil},
-				{ID: "b@test.ch", Name: "b", VacationDays: []string{"2020-04-01"}},
+				{ID: "b@test.ch", Name: "b", VacationDays: vacationDays("2020-04-01")},
 				{ID: "c@test.ch", Name: "c", VacationDays: nil},
 				{ID: "d@test.ch", Name: "d", VacationDays: nil},
 			},
@@ -139,10 +139,10 @@ func TestPlanner_Plan(t *testing.T) {
 		{
 			name: "Should return an error if can not find next available duty",
 			employees: []apis.Employee{
-				{ID: "a@test.ch", Name: "a", VacationDays: []string{"2020-04-01"}},
-				{ID: "b@test.ch", Name: "b", VacationDays: []string{"2020-04-01"}},
-				{ID: "c@test.ch", Name: "c", VacationDays: []string{"2020-04-01"}},
-				{ID: "d@test.ch", Name: "d", VacationDays: []string{"2020-04-01"}},
+				{ID: "a@test.ch", Name: "a", VacationDays: vacationDays("2020-04-01")},
+				{ID: "b@test.ch", Name: "b", VacationDays: vacationDays("2020-04-01")},
+				{ID: "c@test.ch", Name: "c", VacationDays: vacationDays("2020-04-01")},
+				{ID: "d@test.ch", Name: "d", VacationDays: vacationDays("2020-04-01")},
 			},
 			args: args{
 				start:    date("2020-04-01"),
@@ -156,9 +156,9 @@ func TestPlanner_Plan(t *testing.T) {
 			name: "Should return an error if can not find next secondary",
 			employees: []apis.Employee{
 				{ID: "a@test.ch", Name: "a", VacationDays: nil},
-				{ID: "b@test.ch", Name: "b", VacationDays: []string{"2020-04-01"}},
-				{ID: "c@test.ch", Name: "c", VacationDays: []string{"2020-04-01"}},
-				{ID: "d@test.ch", Name: "d", VacationDays: []string{"2020-04-01"}},
+				{ID: "b@test.ch", Name: "b", VacationDays: vacationDays("2020-04-01")},
+				{ID: "c@test.ch", Name: "c", VacationDays: vacationDays("2020-04-01")},
+				{ID: "d@test.ch", Name: "d", VacationDays: vacationDays("2020-04-01")},
 			},
 			args: args{
 				start:    date("2020-04-01"),
@@ -190,4 +190,13 @@ func date(s string) time.Time {
 	}
 
 	return t
+}
+
+func vacationDays(days ...string) []apis.VacationDay {
+	var tmp = make([]apis.VacationDay, len(days))
+	for _, day := range days {
+		tmp = append(tmp, apis.VacationDay{Time: date(day)})
+	}
+
+	return tmp
 }

--- a/pkg/apis/plan_types.go
+++ b/pkg/apis/plan_types.go
@@ -16,6 +16,12 @@ type Rule interface {
 	Match(employee Employee, shifts []Shift, start time.Time, end time.Time) bool
 }
 
+type RuleFunc func(Employee, []Shift, time.Time, time.Time) bool
+
+func (r RuleFunc) Match(employee Employee, shifts []Shift, start time.Time, end time.Time) bool {
+	return r(employee, shifts, start, end)
+}
+
 type Exporter interface {
 	Write(plan []Shift, writer io.Writer) error
 }

--- a/pkg/apis/team_methods.go
+++ b/pkg/apis/team_methods.go
@@ -1,0 +1,20 @@
+package apis
+
+import (
+	"strings"
+	"time"
+)
+
+func (v *VacationDay) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" || string(data) == `""` {
+		return nil
+	}
+
+	date := strings.Trim(string(data), "\"")
+	t, err := time.Parse(time.DateOnly, date)
+	if err != nil {
+		return err
+	}
+	*v = VacationDay{t}
+	return nil
+}

--- a/pkg/apis/team_methods_test.go
+++ b/pkg/apis/team_methods_test.go
@@ -1,0 +1,59 @@
+package apis
+
+import (
+	"testing"
+	"time"
+)
+
+func TestVacationDay_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     []byte
+		want    *VacationDay
+		wantErr bool
+	}{
+		{
+			name:    "Invalid date should throw an error",
+			arg:     []byte("abc"),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Parse a valid date",
+			arg:     []byte("2024-01-01"),
+			want:    &VacationDay{date("2024-01-01")},
+			wantErr: false,
+		},
+		{
+			name:    "Parse a valid date in quotes",
+			arg:     []byte("\"2024-01-01\""),
+			want:    &VacationDay{date("2024-01-01")},
+			wantErr: false,
+		},
+		{
+			name:    "parse empty json string",
+			arg:     []byte("\"\""),
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VacationDay{
+				Time: time.Now(),
+			}
+			err := v.UnmarshalJSON(tt.arg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !(v != nil || tt.want != nil) && tt.want.Equal(v.Time) {
+				t.Errorf("time result = %v, want %v", v, tt.want)
+			}
+		})
+	}
+}
+
+func date(day string) time.Time {
+	t, _ := time.Parse("2006-01-02", day)
+	return t
+}

--- a/pkg/apis/team_types.go
+++ b/pkg/apis/team_types.go
@@ -1,8 +1,6 @@
 package apis
 
 import (
-	"encoding/json"
-	"fmt"
 	"time"
 )
 
@@ -12,49 +10,12 @@ type Team struct {
 	Employees []Employee `json:"employees"`
 }
 
+type VacationDay struct {
+	time.Time
+}
+
 type Employee struct {
-	ID              EmployeeID `json:"id"`
-	Name            string     `json:"name"`
-	VacationDays    []string   `json:"vacationDays,omitempty"`
-	parsedVacations []time.Time
-}
-
-func (e *Employee) UnmarshalJSON(data []byte) error {
-	type Alias Employee
-	temp := &struct {
-		*Alias
-	}{
-		Alias: (*Alias)(e),
-	}
-
-	if err := json.Unmarshal(data, &temp); err != nil {
-		return err
-	}
-
-	parsedDay, err := parseDateOnly(e.VacationDays)
-	if err != nil {
-		return err
-	}
-	e.parsedVacations = parsedDay
-
-	return nil
-}
-
-func (e *Employee) Vacations() []time.Time {
-	if len(e.VacationDays) != len(e.parsedVacations) {
-		e.parsedVacations, _ = parseDateOnly(e.VacationDays)
-	}
-	return e.parsedVacations
-}
-
-func parseDateOnly(dateStr []string) ([]time.Time, error) {
-	days := make([]time.Time, len(dateStr))
-	for idx, day := range dateStr {
-		t, err := time.Parse(time.DateOnly, day)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse date '%s'", day)
-		}
-		days[idx] = t
-	}
-	return days, nil
+	ID           EmployeeID    `json:"id"`
+	Name         string        `json:"name"`
+	VacationDays []VacationDay `json:"vacationDays,omitempty"`
 }


### PR DESCRIPTION
resolve #8 

# Context
Standard rules for primary and secondary on-call duty can be defined via CLI 